### PR TITLE
changing name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
      -->
     </properties>
     <name>ByteGuard Build Actions</name>
-    <description>Bytegaurd Build Actions enable notification during build</description>
+    <description>ByteGuard Build Actions enable notification during build</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
-    <artifactId>byteguard-jenkins-build-actions-plugin</artifactId>
+    <artifactId>Byteguard-Build-Actions</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
@@ -21,8 +21,8 @@
           ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
      -->
     </properties>
-    <name>Byteguard Jenkins Actions Plugin</name>
-    <description>This will enable notifications during build</description>
+    <name>Bytegaurd Build Actions</name>
+    <description>Bytegaurd Build Actions enable notification during build</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
           ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
      -->
     </properties>
-    <name>Bytegaurd Build Actions</name>
+    <name>ByteGuard Build Actions</name>
     <description>Bytegaurd Build Actions enable notification during build</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>

--- a/src/main/java/io/jenkins/plugins/sample/BytegaurdActionBuilder.java
+++ b/src/main/java/io/jenkins/plugins/sample/BytegaurdActionBuilder.java
@@ -93,7 +93,7 @@ public class BytegaurdActionBuilder extends Builder implements SimpleBuildStep {
 
         @Override
         public String getDisplayName() {
-            return "Bytegaurd Jenkins Build Actions";
+            return "Bytegaurd Build Actions";
         }
 
     }

--- a/src/main/java/io/jenkins/plugins/sample/BytegaurdActionBuilder.java
+++ b/src/main/java/io/jenkins/plugins/sample/BytegaurdActionBuilder.java
@@ -93,7 +93,7 @@ public class BytegaurdActionBuilder extends Builder implements SimpleBuildStep {
 
         @Override
         public String getDisplayName() {
-            return "Bytegaurd Build Actions";
+            return "ByteGuard Build Actions";
         }
 
     }


### PR DESCRIPTION
Hello Victor,
I got a requirement that plugin name should not contain words like plugin and jenkins. They suggested name "Byteguard-Build-Actions". I have change files. Please change the name of repo to "Byteguard-Build-Actions" and merge this pull request so that we can go to step forward in this process.

Thanks
Khushboo