### PR TITLE
Changing name to lowercase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <relativePath />
     </parent>
     <groupId>io.jenkins.plugins</groupId>
-    <artifactId>Byteguard-Build-Actions</artifactId>
+    <artifactId>byteguard-build-actions</artifactId>
     <version>1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
@@ -21,7 +21,7 @@
           ~ stapler-plugin.version: The Stapler Maven plugin version required by the plugin.
      -->
     </properties>
-    <name>ByteGuard Build Actions</name>
+    <name>ByteGuard Build Actions Plugin</name>
     <description>ByteGuard Build Actions enable notification during build</description>
     <!-- The default licence for Jenkins OSS Plugins is MIT. Substitute for the applicable one if needed. -->
     <licenses>


### PR DESCRIPTION
Hello Victor,
I got response that the artifactId is still wrong, it MUST be all lower case. So I have created a new project with name "byteguard-build-actions". We can use the same src in new project. That's why I only changed pom.xml.Please change the name of repo to lowercase as well.

Thanks
Khushboo